### PR TITLE
Fix release build boxed_on_debug macro

### DIFF
--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -22,3 +22,11 @@ macro_rules! boxed_on_debug {
         $x.boxed()
     };
 }
+
+#[macro_export]
+#[cfg(not(debug_assertions))]
+macro_rules! boxed_on_debug {
+    ($x:expr) => {
+        $x
+    };
+}


### PR DESCRIPTION
While I recognize that this project is meant to be a snapshot when building (rust 1.56.0 x86_64-unknown-linux-musl) as follows 

```console
docker run -ti  --rm --user "$(id -u)":"$(id -g)" -v "$PWD":/usr/src/myapp -w /usr/src/myapp rust:1.56.0 /bin/sh
rustup target add rustup target add x86_64-unknown-linux-musl
cargo build --release --target x86_64-unknown-linux-musl
```

I got the below error which this PR fixes. 

```console
error: cannot find macro `boxed_on_debug` in this scope
   --> src/api/macros.rs:6:26
    |
6   |       ($x:expr $(,)?) => { boxed_on_debug!($x) };
    |                            ^^^^^^^^^^^^^^
    |
   ::: src/api/mod.rs:122:21
    |
122 |           warp::serve(combine!(
    |  _____________________-
123 | |             get_status,
124 | |             get_exit_code,
125 | |             post_signals,
...   |
128 | |             ws_exec,
129 | |         ))
    | |_________- in this macro invocation
    |
    = note: this error originates in the macro `combine` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `fly-init` due to 6 previous errors
```